### PR TITLE
關閉寄發信件錯誤時的錯誤頁面、移除 gem mailgun-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,5 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-github', github: 'omniauth/omniauth-github', branch:'master'
 gem 'omniauth-rails_csrf_protection'
 
-
-gem "mailgun-ruby", "~> 1.2"
 #   icon
 gem "font-awesome-sass", "~> 6.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,8 +106,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -125,9 +123,6 @@ GEM
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
-    http-accept (1.7.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -155,14 +150,9 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mailgun-ruby (1.2.8)
-      rest-client (>= 2.0.2)
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.0)
@@ -176,7 +166,6 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.14.2-aarch64-linux)
       racc (~> 1.4)
@@ -259,11 +248,6 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -301,9 +285,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
     version_gem (1.1.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -342,7 +323,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   letter_opener
-  mailgun-ruby (~> 1.2)
   omniauth-github!
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   }
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
1. 目前Mailgun帳號尚未升級，只能寄email給已加入測試白名單的email。其他email無法寄出會報出錯誤頁面，所以暫時把錯誤頁面關掉。
2. 移除沒有用到的gem: mailgun-rails

